### PR TITLE
Enhance API Documentation Workflow with Redocly CLI and Deployment Key Support

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Deploy to Github pages
       uses: peaceiris/actions-gh-pages@v4
       with:
-        GITHUB_TOKEN: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         publish_dir: . 
         force_orphan: true
         exclude_assets: '.github,openapi,.redocly.yaml,make.sh'

--- a/make.sh
+++ b/make.sh
@@ -4,5 +4,5 @@ echo "Building API Docs"
 
 # Bundle the API docs
 
-npx @redocly/cli bundle -o sfgoa3.yaml && \
+npx @redocly/cli bundle ./openapi/openapi.yaml -o sfgoa3.yaml && \
 npx @redocly/cli build-docs sfgoa3.yaml -o index.html


### PR DESCRIPTION
## What/Why/How?


**Path to openapi.yaml for Redocly CLI:**

Updated the setup to explicitly provide the path to openapi.yaml as input to the Redocly CLI for creating the bundle.


**Deployment Key for GitHub Pages Workflow**:

Adjusted the workflow to use deploy_key instead of GITHUB_TOKEN for deploying to GitHub Pages.